### PR TITLE
Update dependency range for Rails 6.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.5', '2.7', '3.0']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
       uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler: '1.17.3'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
       with:
         ruby-version: ${{ matrix.ruby-version }}
+        bundler: '1.17.3'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,3 @@
+source "http://rubygems.org"
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source "http://rubygems.org"
 
+group :test do
+  gem 'pry'
+  gem 'pry-byebug'
+end
+
 gemspec

--- a/acts_as_replaceable.gemspec
+++ b/acts_as_replaceable.gemspec
@@ -8,9 +8,8 @@ Gem::Specification.new do |s|
   s.authors = ['Nicholas Jakobsen', 'Ryan Wallace']
   s.files = Dir.glob("{lib,spec}/**/*") + %w(README.rdoc)
 
-  s.add_dependency('rails', ">= 4.0.6")
+  s.add_dependency('rails', [">= 4.0.6", "< 7"])
 
-  s.add_development_dependency('bundler', '~> 1.5')
   s.add_development_dependency('sqlite3', '~> 1.3')
   s.add_development_dependency('rspec-rails', '~> 2.0')
 end

--- a/lib/acts_as_replaceable/acts_as_replaceable.rb
+++ b/lib/acts_as_replaceable/acts_as_replaceable.rb
@@ -40,6 +40,10 @@ module ActsAsReplaceable
 
   module HelperMethods
     def self.sanitize_attribute_names(klass, *args)
+      unless klass.connected? && klass.table_exists?
+        ActiveRecord::Base.logger.warn "(acts_as_replaceable) unable to connect to table `#{klass.table_name}` so excluding all attribute names"
+        return []
+      end
       # Intersect the proposed attributes with the column names so we don't start assigning attributes that don't exist. e.g. if the model doesn't have timestamps
       klass.column_names & args.flatten.compact.collect(&:to_s)
     end

--- a/lib/acts_as_replaceable/acts_as_replaceable.rb
+++ b/lib/acts_as_replaceable/acts_as_replaceable.rb
@@ -175,6 +175,14 @@ module ActsAsReplaceable
       # Inherit target's attributes for those in acts_as_replaceable_options[:inherit]
       ActsAsReplaceable::HelperMethods.copy_attributes(acts_as_replaceable_options[:inherit], existing, self)
 
+      # Rails 5 introduced AR::Dirty and started using `mutations_from_database` to
+      # lookup `id_in_database` which is required for the `_update_record` call
+      #
+      # This chunk of code is copied from https://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-becomes
+      if existing.respond_to?(:mutations_from_database, true)
+        instance_variable_set("@mutations_from_database", existing.send(:mutations_from_database) || nil)
+      end
+
       @new_record        = false
       @has_been_replaced = true
       @has_not_changed   = !ActsAsReplaceable::HelperMethods.mark_changes(self, existing)

--- a/lib/acts_as_replaceable/acts_as_replaceable.rb
+++ b/lib/acts_as_replaceable/acts_as_replaceable.rb
@@ -1,4 +1,4 @@
-require 'digest'
+require 'openssl'
 require 'timeout'
 
 module ActsAsReplaceable
@@ -104,7 +104,7 @@ module ActsAsReplaceable
     # eg. In a multi-threaded environment, 'find_or_create' is prone to failure due to the possibility
     # that the process is preempted between the 'find' and 'create' logic
     def self.lock(record, timeout = 20)
-      lock_id  = "ActsAsReplaceable/#{Digest::MD5.digest([match_conditions(record), insensitive_match_conditions(record)].inspect)}"
+      lock_id  = "ActsAsReplaceable/#{OpenSSL::Digest::MD5.digest([match_conditions(record), insensitive_match_conditions(record)].inspect)}"
       acquired = false
 
       # Acquire the lock by atomically incrementing and returning the value to see if we're first

--- a/spec/acts_as_replaceable_spec.rb
+++ b/spec/acts_as_replaceable_spec.rb
@@ -109,6 +109,12 @@ describe 'acts_as_dag' do
       Person.where(:first_name => 'John').count.should == 1
     end
 
+    it "should correctly detect difference between blank and nil values" do
+      a = Person.create! :first_name => 'John', :last_name => ''
+      a = Person.create! :first_name => 'John', :last_name => nil
+      Person.where(:first_name => 'John').count.should == 2
+    end
+
     it "should inherit the id of the existing record" do
       a = Material.create! :name => 'wood'
       b = Material.create! :name => 'wood'

--- a/spec/acts_as_replaceable_spec.rb
+++ b/spec/acts_as_replaceable_spec.rb
@@ -14,6 +14,16 @@ describe 'acts_as_dag' do
     end
   end
 
+  describe "Model" do
+    it 'evaluates without error when no database table exists' do
+      eval("class NoTable < ActiveRecord::Base; end")
+      klass = NoTable
+
+      klass.table_name = "some_table_that_does_not_exist"
+      expect(klass.acts_as_replaceable).to be_nil
+    end
+  end
+
   describe "Helper Methods" do
     before(:each) { @record = insert_model(Material, :name => 'glass')}
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ $LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
 require 'active_record'
 require 'logger'
 require 'acts_as_replaceable'
+require 'byebug'
 
 ActiveRecord::Base.logger = Logger.new(STDOUT)
 ActiveRecord::Base.logger.level = Logger::INFO


### PR DESCRIPTION
This has a failing test that I believe was failing before bumping the Rails version:

```
Failures:

  1) acts_as_dag when saving a record should update the non-match, non-inherit fields of the existing record
     Failure/Error: c.first.name.should == 'Dip Stick'
       expected: "Dip Stick"
            got: "Stick" (using ==)
     # ./spec/acts_as_replaceable_spec.rb:80:in `block (3 levels) in <top (required)>'
```
