### PR TITLE
Prevent AR scope leaking into `find_existing`

### DIFF
--- a/acts_as_replaceable.gemspec
+++ b/acts_as_replaceable.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.authors = ['Nicholas Jakobsen', 'Ryan Wallace']
   s.files = Dir.glob("{lib,spec}/**/*") + %w(README.rdoc)
 
-  s.add_dependency('rails', [">= 4.0.6", "< 7"])
+  s.add_dependency('rails', [">= 4.1.8", "< 7"])
 
   s.add_development_dependency('sqlite3', '~> 1.3')
   s.add_development_dependency('rspec-rails', '~> 2.0')

--- a/lib/acts_as_replaceable/acts_as_replaceable.rb
+++ b/lib/acts_as_replaceable/acts_as_replaceable.rb
@@ -90,7 +90,7 @@ module ActsAsReplaceable
 
     # Searches the database for an existing copies of record
     def self.find_existing(record)
-      existing = record.class
+      existing = record.class.default_scoped
       existing = existing.where match_conditions(record)
       existing = existing.where insensitive_match_conditions(record)
     end


### PR DESCRIPTION
This addresses a Rails 6.1 deprecation warning to address scope leakage:
https://github.com/rails/rails/pull/32380

`default_scoped` was introduced in Rails 4.1.8:
https://apidock.com/rails/v6.1.3.1/ActiveRecord/Scoping/Named/ClassMethods/default_scoped