### PR TITLE
Data mapper updates

### DIFF
--- a/acts_as_replaceable.gemspec
+++ b/acts_as_replaceable.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.authors = ['Nicholas Jakobsen', 'Ryan Wallace']
   s.files = Dir.glob("{lib,spec}/**/*") + %w(README.rdoc)
 
-  s.add_dependency('rails', [">= 4.1.8", "< 7"])
+  s.add_dependency('rails', [">= 4.1.8", "< 8"])
 
-  s.add_development_dependency('sqlite3', '~> 1.3')
-  s.add_development_dependency('rspec-rails', '~> 2.0')
+  s.add_development_dependency('sqlite3')
+  s.add_development_dependency('rspec-rails')
 end

--- a/lib/acts_as_replaceable/acts_as_replaceable.rb
+++ b/lib/acts_as_replaceable/acts_as_replaceable.rb
@@ -40,8 +40,8 @@ module ActsAsReplaceable
 
   module HelperMethods
     def self.sanitize_attribute_names(klass, *args)
-      unless klass.connected? && klass.table_exists?
-        ActiveRecord::Base.logger.warn "(acts_as_replaceable) unable to connect to table `#{klass.table_name}` so excluding all attribute names"
+      unless klass.table_exists?
+        ActiveRecord::Base.logger.warn "(acts_as_replaceable) table `#{klass.table_name}` does not exist so excluding all attribute names"
         return []
       end
       # Intersect the proposed attributes with the column names so we don't start assigning attributes that don't exist. e.g. if the model doesn't have timestamps

--- a/lib/acts_as_replaceable/acts_as_replaceable.rb
+++ b/lib/acts_as_replaceable/acts_as_replaceable.rb
@@ -68,6 +68,8 @@ module ActsAsReplaceable
           sql << "#{attribute_name} IS NULL"
         end
       end
+
+      return nil if sql.empty?
       return [sql.join(' AND ')] + binds
     end
 


### PR DESCRIPTION
This was previously returning `[""]` which breaks Rails 5 `where` queries, e.g.

```
HoldingInstitution.where([""]).to_a
  HoldingInstitution Load (0.3ms)  SELECT "holding_institutions".* FROM "holding_institutions" WHERE
ActiveRecord::StatementInvalid: PG::SyntaxError: ERROR:  syntax error at end of input
LINE 1: ... "holding_institutions".* FROM "holding_institutions" WHERE
```